### PR TITLE
feat(mcp-agent): add MCP tool-calling agent + code review fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,14 @@ baseline = [
     "litellm",
     "python-dotenv",
 ]
+mcp-agent = [
+    # MCP tool-calling agent via build123d-mcp server.
+    # build123d-mcp itself must be installed separately (pip install build123d-mcp
+    # or uvx build123d-mcp). This extra only covers the cadgenbench-side deps.
+    "mcp>=1.0",
+    "litellm",
+    "python-dotenv",
+]
 dev = [
     "pytest",
     "ruff",

--- a/src/cadgenbench/baseline/__init__.py
+++ b/src/cadgenbench/baseline/__init__.py
@@ -19,15 +19,6 @@ gets a render + validity check of its output each turn, and signals
 completion with ``[DONE]``.
 """
 
-from cadgenbench.baseline.agent import run_agent
-from cadgenbench.baseline.types import (
-    AgentConfig,
-    AgentResult,
-    CodeExecution,
-    TurnRecord,
-    save_conversation,
-)
-
 __all__ = [
     "run_agent",
     "AgentConfig",
@@ -36,3 +27,21 @@ __all__ = [
     "TurnRecord",
     "save_conversation",
 ]
+
+_LAZY = {
+    "run_agent": ("cadgenbench.baseline.agent", "run_agent"),
+    "AgentConfig": ("cadgenbench.baseline.types", "AgentConfig"),
+    "AgentResult": ("cadgenbench.baseline.types", "AgentResult"),
+    "CodeExecution": ("cadgenbench.baseline.types", "CodeExecution"),
+    "TurnRecord": ("cadgenbench.baseline.types", "TurnRecord"),
+    "save_conversation": ("cadgenbench.baseline.types", "save_conversation"),
+}
+
+
+def __getattr__(name: str):  # noqa: N807
+    if name in _LAZY:
+        module_name, attr = _LAZY[name]
+        import importlib
+        mod = importlib.import_module(module_name)
+        return getattr(mod, attr)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/cadgenbench/baseline/_cli.py
+++ b/src/cadgenbench/baseline/_cli.py
@@ -42,8 +42,6 @@ from pathlib import Path
 
 import yaml
 
-from cadgenbench.baseline import AgentConfig, AgentResult, run_agent
-from cadgenbench.baseline.llm import LLMClient
 from cadgenbench.eval.evaluate import evaluate_candidate_only, evaluate_result
 from cadgenbench.eval.shape_similarity import METRIC_DISPLAY
 
@@ -85,6 +83,7 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
 
     # Argparse defaults come straight from AgentConfig(), which itself reads
     # default_config.yaml at import time.  Single source of truth.
+    from cadgenbench.baseline import AgentConfig  # noqa: PLC0415
     defaults = AgentConfig()
 
     p.add_argument("fixtures", nargs="*",
@@ -181,6 +180,8 @@ def run(args: argparse.Namespace) -> int:
         limit=args.limit,
     )
 
+    from cadgenbench.baseline import AgentConfig  # noqa: PLC0415
+    from cadgenbench.baseline.llm import LLMClient  # noqa: PLC0415
     parallel = max(1, args.parallel)
     resolved_model = LLMClient(model=args.model).model
 
@@ -374,6 +375,7 @@ def _run_one_task(
     if input_files:
         logs.append(f"Input files: {', '.join(f.name for f in input_files)}")
 
+    from cadgenbench.baseline import run_agent  # noqa: PLC0415
     out_dir = run_dir / name
     result = run_agent(
         description,

--- a/src/cadgenbench/baseline/llm.py
+++ b/src/cadgenbench/baseline/llm.py
@@ -547,7 +547,7 @@ class LLMClient:
             )
 
         raw_tool_calls = getattr(message, "tool_calls", None) or None
-        stop_reason = response.choices[0].finish_reason if response.choices else None
+        stop_reason = getattr(response.choices[0], "finish_reason", None) if response.choices else None
 
         return CompletionResult(
             content=content,

--- a/src/cadgenbench/baseline/llm.py
+++ b/src/cadgenbench/baseline/llm.py
@@ -192,6 +192,15 @@ class CompletionResult:
     ``usage.completion_tokens_details.reasoning_tokens``. ``reasoning_content``
     mirrors LiteLLM's ``message.reasoning_content`` and is the decoded CoT
     text when the provider returns it separately from the answer.
+
+    ``tool_calls`` is populated when the model responds with tool-use calls
+    instead of (or in addition to) text. Each element is a LiteLLM
+    ``ChatCompletionMessageToolCall`` with ``.id``, ``.function.name``, and
+    ``.function.arguments`` (JSON string). ``None`` means the model did not
+    call any tools this turn.
+
+    ``stop_reason`` mirrors ``choices[0].finish_reason`` (e.g. ``"stop"``,
+    ``"tool_calls"``, ``"end_turn"``).
     """
 
     content: str
@@ -202,6 +211,8 @@ class CompletionResult:
     raw: Any = field(repr=False)
     reasoning_tokens: int | None = None
     reasoning_content: str | None = None
+    tool_calls: list[Any] | None = None
+    stop_reason: str | None = None
 
 
 # Matches a full ``<think>...</think>`` block (greedy across newlines), with
@@ -535,6 +546,9 @@ class LLMClient:
                 reasoning_tokens,
             )
 
+        raw_tool_calls = getattr(message, "tool_calls", None) or None
+        stop_reason = response.choices[0].finish_reason if response.choices else None
+
         return CompletionResult(
             content=content,
             prompt_tokens=prompt_tokens,
@@ -544,4 +558,6 @@ class LLMClient:
             raw=response,
             reasoning_tokens=reasoning_tokens,
             reasoning_content=reasoning_content,
+            tool_calls=raw_tool_calls,
+            stop_reason=stop_reason,
         )

--- a/src/cadgenbench/cli.py
+++ b/src/cadgenbench/cli.py
@@ -59,6 +59,9 @@ def main(argv: list[str] | None = None) -> int:
     from cadgenbench.eval.report.single_run import add_subparser as add_report_single
     add_report_single(report_sub)
 
+    # cadgenbench mcp-agent run (needs [mcp-agent] extra).
+    mcp_agent_p = _register_mcp_agent_subcommand(subparsers)
+
     args = parser.parse_args(argv)
 
     if not hasattr(args, "handler"):
@@ -68,6 +71,8 @@ def main(argv: list[str] | None = None) -> int:
             parser.print_help()
         elif args.command == "baseline" and baseline_p is not None:
             baseline_p.print_help()
+        elif args.command == "mcp-agent" and mcp_agent_p is not None:
+            mcp_agent_p.print_help()
         elif args.command == "report":
             report_p.print_help()
         else:
@@ -103,6 +108,28 @@ def _register_baseline_subcommand(
     add_baseline_run(baseline_sub)
     add_baseline_package(baseline_sub)
     return baseline_p
+
+
+def _register_mcp_agent_subcommand(
+    subparsers: argparse._SubParsersAction,
+) -> argparse.ArgumentParser | None:
+    """Register the ``mcp-agent`` subcommand if its extras are installed.
+
+    Requires the ``cadgenbench[mcp-agent]`` optional dependencies (mcp SDK,
+    litellm, python-dotenv). Degrades gracefully when not installed.
+    """
+    try:
+        from cadgenbench.mcp_agent._cli import add_subparser as add_mcp_run
+    except ImportError:
+        return None
+
+    mcp_p = subparsers.add_parser(
+        "mcp-agent",
+        help="MCP tool-calling agent commands.",
+    )
+    mcp_sub = mcp_p.add_subparsers(dest="mcp_agent_action")
+    add_mcp_run(mcp_sub)
+    return mcp_p
 
 
 if __name__ == "__main__":

--- a/src/cadgenbench/mcp_agent/__init__.py
+++ b/src/cadgenbench/mcp_agent/__init__.py
@@ -1,0 +1,36 @@
+# Copyright 2026 Hugging Face
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MCP-agent strategy for CADGenBench.
+
+Uses the build123d-mcp server's native tool-calling interface instead of
+code-block extraction. The LLM calls execute(), render_view(), measure(),
+export(), and signal_done() as tools; the benchmark connects to a running
+build123d-mcp server via its stdio MCP protocol.
+"""
+
+__all__ = ["run_mcp_agent", "McpAgentConfig", "McpAgentResult"]
+
+
+def __getattr__(name: str):  # noqa: N807
+    if name == "run_mcp_agent":
+        from cadgenbench.mcp_agent.agent import run_mcp_agent
+        return run_mcp_agent
+    if name == "McpAgentConfig":
+        from cadgenbench.mcp_agent.types import McpAgentConfig
+        return McpAgentConfig
+    if name == "McpAgentResult":
+        from cadgenbench.mcp_agent.types import McpAgentResult
+        return McpAgentResult
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/cadgenbench/mcp_agent/_cli.py
+++ b/src/cadgenbench/mcp_agent/_cli.py
@@ -35,18 +35,10 @@ from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
 
-import yaml
-
 from cadgenbench.mcp_agent.types import McpAgentConfig, McpAgentResult
 from cadgenbench.eval.evaluate import evaluate_candidate_only, evaluate_result
 
 GT_STEP_NAME = "ground_truth.step"
-DISPLAYED_METRICS: tuple[str, ...] = (
-    "cad_score",
-    "shape_similarity_score",
-    "shape_surface_distance_f1",
-    "shape_volume_iou",
-)
 
 _DEFAULT_OUTPUT_REL = Path("results")
 

--- a/src/cadgenbench/mcp_agent/_cli.py
+++ b/src/cadgenbench/mcp_agent/_cli.py
@@ -1,0 +1,309 @@
+# Copyright 2026 Hugging Face
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``cadgenbench mcp-agent run`` subcommand handler.
+
+Run the MCP-agent on one or more benchmark fixtures.  Uses the build123d-mcp
+server's native tool-calling interface rather than code-block extraction.
+
+Usage::
+
+    cadgenbench mcp-agent run 101
+    cadgenbench mcp-agent run --all --parallel 4
+    cadgenbench mcp-agent run --all --model openai/gpt-4o --mcp-server uvx --mcp-args build123d-mcp
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import textwrap
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+from cadgenbench.mcp_agent.types import McpAgentConfig, McpAgentResult
+from cadgenbench.eval.evaluate import evaluate_candidate_only, evaluate_result
+
+GT_STEP_NAME = "ground_truth.step"
+DISPLAYED_METRICS: tuple[str, ...] = (
+    "cad_score",
+    "shape_similarity_score",
+    "shape_surface_distance_f1",
+    "shape_volume_iou",
+)
+
+_DEFAULT_OUTPUT_REL = Path("results")
+
+
+# ---------------------------------------------------------------------------
+# CLI registration
+# ---------------------------------------------------------------------------
+
+def add_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Register the ``cadgenbench mcp-agent run`` subcommand."""
+    p = subparsers.add_parser(
+        "run",
+        help="Run the MCP-agent on one or more fixtures.",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""\
+            examples:
+              %(prog)s 101
+              %(prog)s --all --parallel 4
+              %(prog)s --all --model anthropic/claude-opus-4-8
+              %(prog)s 101 --mcp-server uvx --mcp-args build123d-mcp
+        """),
+    )
+
+    defaults = McpAgentConfig()
+
+    p.add_argument("fixtures", nargs="*", help="Fixture name(s) from data/inputs/")
+    p.add_argument("--all", action="store_true", help="Run all fixtures")
+    p.add_argument("--limit", type=int, default=None, help="Max number of fixtures to run")
+    p.add_argument("--model", default=defaults.model, help="LiteLLM model string")
+    p.add_argument("--max-iter", type=int, default=defaults.max_iterations,
+                   help=f"Max agent turns (default: {defaults.max_iterations})")
+    p.add_argument("--max-tokens", type=int, default=defaults.max_total_tokens,
+                   help=f"Max total tokens (default: {defaults.max_total_tokens})")
+    p.add_argument("--max-tokens-per-call", type=int, default=defaults.max_tokens,
+                   help=f"Max completion tokens per LLM call (default: {defaults.max_tokens})")
+    p.add_argument("--max-duration", type=float, default=defaults.max_duration_s,
+                   help=f"Max wall-clock seconds (default: {defaults.max_duration_s:.0f})")
+    p.add_argument("--llm-timeout", type=float, default=defaults.llm_timeout,
+                   help=f"Per-LLM-call timeout in seconds (default: {defaults.llm_timeout:.0f})")
+    p.add_argument("--parallel", type=int, default=1, metavar="N",
+                   help="Run N fixtures in parallel (default: 1)")
+    p.add_argument("--mcp-server", default=defaults.mcp_server_command,
+                   help=(f"Command to launch the build123d-mcp server "
+                         f"(default: {defaults.mcp_server_command!r}). "
+                         "Use 'uvx' with --mcp-args build123d-mcp for uvx installs."))
+    p.add_argument("--mcp-args", nargs="*", default=defaults.mcp_server_args,
+                   help="Extra args passed to the MCP server command")
+    p.add_argument("--output-dir", type=Path, default=None,
+                   help=f"Results directory (default: ./{_DEFAULT_OUTPUT_REL}/)")
+
+    p.set_defaults(handler=run)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand entry point
+# ---------------------------------------------------------------------------
+
+def run(args: argparse.Namespace) -> int:
+    """Execute ``cadgenbench mcp-agent run``."""
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(levelname)s [%(name)s] %(message)s",
+    )
+
+    from cadgenbench.common.paths import (
+        data_inputs_dir as _data_inputs_dir,
+        data_gt_dir as _data_gt_dir,
+    )
+
+    try:
+        data_inputs_dir = _data_inputs_dir()
+    except FileNotFoundError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+
+    try:
+        data_gt_dir = _data_gt_dir()
+    except FileNotFoundError:
+        data_gt_dir = None
+    except Exception as e:  # noqa: BLE001
+        logging.getLogger(__name__).warning(
+            "Ground-truth dataset not accessible (%s: %s); skipping local scoring.",
+            type(e).__name__, e,
+        )
+        data_gt_dir = None
+
+    output_dir = args.output_dir or Path.cwd() / _DEFAULT_OUTPUT_REL
+
+    from cadgenbench.baseline._cli import _discover_fixtures  # lazy: needs litellm
+    tasks = _discover_fixtures(
+        data_inputs_dir, data_gt_dir,
+        names=args.fixtures or None,
+        run_all=args.all,
+        limit=args.limit,
+    )
+
+    config = McpAgentConfig(
+        model=args.model,
+        max_tokens=args.max_tokens_per_call,
+        max_total_tokens=args.max_tokens,
+        max_iterations=args.max_iter,
+        max_duration_s=args.max_duration,
+        llm_timeout=args.llm_timeout,
+        mcp_server_command=args.mcp_server,
+        mcp_server_args=args.mcp_args or [],
+    )
+
+    parallel = max(1, args.parallel)
+
+    print(f"Fixtures: {', '.join(t['name'] for t in tasks)}")
+    print(f"Model:    {config.model}")
+    print(f"MCP:      {config.mcp_server_command} {' '.join(config.mcp_server_args)}")
+    print(f"Config:   max_iter={config.max_iterations}, max_tokens={config.max_total_tokens}, "
+          f"max_duration={config.max_duration_s}s")
+    if parallel > 1:
+        print(f"Parallel: {parallel} fixtures")
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    model_slug = config.model.split("/")[-1]
+    run_dir = output_dir / f"{timestamp}_{model_slug}_mcp"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    (run_dir / "params.json").write_text(json.dumps({
+        "timestamp": timestamp,
+        "fixtures": [t["name"] for t in tasks],
+        "config": asdict(config),
+        "parallel": parallel,
+        "agent": "mcp",
+    }, indent=2))
+
+    all_results = _run_all(tasks, config=config, run_dir=run_dir, parallel=parallel)
+    _print_summary(all_results)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Per-fixture run + evaluation
+# ---------------------------------------------------------------------------
+
+def _run_one_task(
+    task: dict,
+    *,
+    config: McpAgentConfig,
+    run_dir: Path,
+) -> tuple[str, McpAgentResult, list[str]]:
+    name = task["name"]
+    description = task["description"]
+    task_type = task.get("task_type", "generation")
+
+    input_files = None
+    raw_files = task.get("input_files")
+    if raw_files:
+        inputs_dir = Path(task["_inputs_dir"])
+        input_files = [inputs_dir / f for f in raw_files]
+
+    logs = [
+        f"\n--- {name} ({task_type}) ---",
+        f"Task: {description[:100]}…",
+    ]
+    if input_files:
+        logs.append(f"Input files: {', '.join(f.name for f in input_files)}")
+
+    from cadgenbench.mcp_agent.agent import run_mcp_agent  # lazy: needs litellm+mcp
+    out_dir = run_dir / name
+    result = run_mcp_agent(
+        description,
+        config=config,
+        input_files=input_files,
+        output_dir=out_dir,
+    )
+    logs.append(f"Results: {out_dir}")
+    logs.append(
+        f"  Turns: {len(result.turns)}, tokens: {result.total_tokens}, "
+        f"stop: {result.stopped_reason}, done: {result.completed}"
+    )
+
+    candidate = result.candidate_step
+    gt_dir = Path(task["_gt_dir"]) if task.get("_gt_dir") else None
+    gt_step = gt_dir / GT_STEP_NAME if gt_dir else None
+
+    if gt_step and gt_step.exists() and candidate and candidate.exists():
+        evaluate_result(out_dir, gt_dir, candidate_step=candidate)
+        data = json.loads((out_dir / "result.json").read_text())
+        from cadgenbench.baseline._cli import _metric_summary_lines  # lazy
+        logs.extend(_metric_summary_lines(data))
+    elif candidate and candidate.exists():
+        evaluate_candidate_only(candidate, out_dir)
+    else:
+        logs.append("  Evaluation skipped: no output.step produced")
+
+    return name, result, logs
+
+
+def _run_all(
+    tasks: list[dict],
+    *,
+    config: McpAgentConfig,
+    run_dir: Path,
+    parallel: int,
+) -> list[tuple[str, McpAgentResult]]:
+    all_results: list[tuple[str, McpAgentResult]] = []
+
+    if parallel <= 1:
+        for task in tasks:
+            try:
+                name, result, logs = _run_one_task(task, config=config, run_dir=run_dir)
+                for line in logs:
+                    print(line)
+                all_results.append((name, result))
+            except Exception:
+                print(f"\n--- {task['name']} FAILED ---")
+                logging.getLogger(__name__).exception(
+                    "Fixture %s raised an exception", task["name"]
+                )
+    else:
+        with ProcessPoolExecutor(max_workers=parallel) as pool:
+            futures = {
+                pool.submit(_run_one_task, task, config=config, run_dir=run_dir): task["name"]
+                for task in tasks
+            }
+            for future in as_completed(futures):
+                fixture_name = futures[future]
+                try:
+                    name, result, logs = future.result()
+                    for line in logs:
+                        print(line)
+                    all_results.append((name, result))
+                except Exception:
+                    print(f"\n--- {fixture_name} FAILED ---")
+                    logging.getLogger(__name__).exception(
+                        "Fixture %s raised an exception", fixture_name
+                    )
+
+    task_order = {t["name"]: i for i, t in enumerate(tasks)}
+    all_results.sort(key=lambda r: task_order.get(r[0], 0))
+
+    try:
+        from cadgenbench.eval.run_summary import write_run_summary
+        summary_path = write_run_summary(run_dir)
+        print(f"Wrote {summary_path.name}")
+    except Exception:
+        logging.getLogger(__name__).exception("write_run_summary failed for %s", run_dir)
+
+    return all_results
+
+
+def _print_summary(results: list[tuple[str, McpAgentResult]]) -> None:
+    header = f"{'fixture':<25} {'turns':>5} {'tokens':>8} {'time':>7} {'stop':>12} {'done':>5}"
+    print("\n" + "=" * len(header))
+    print(header)
+    print("-" * len(header))
+    for name, result in results:
+        done = "yes" if result.completed else "no"
+        print(
+            f"{name:<25} {len(result.turns):>5} "
+            f"{result.total_tokens:>8} "
+            f"{result.total_duration_s:>6.1f}s {result.stopped_reason:>12} {done:>5}"
+        )
+    print("=" * len(header) + "\n")

--- a/src/cadgenbench/mcp_agent/agent.py
+++ b/src/cadgenbench/mcp_agent/agent.py
@@ -87,6 +87,7 @@ def run_mcp_agent(
     Returns:
         McpAgentResult with per-turn records, totals, and stopping reason.
     """
+    _work_dir_owned = work_dir is None
     if work_dir is None:
         work_dir = Path(tempfile.mkdtemp(prefix="cadgenbench_mcp_"))
     work_dir.mkdir(parents=True, exist_ok=True)
@@ -135,7 +136,14 @@ def run_mcp_agent(
         except Exception:
             logger.warning("Incremental save failed", exc_info=True)
 
-    with McpSession(config.mcp_server_command, config.mcp_server_args) as mcp:
+    mcp = McpSession(config.mcp_server_command, config.mcp_server_args)
+    try:
+        mcp.start()
+    except BaseException:
+        if _work_dir_owned:
+            shutil.rmtree(work_dir, ignore_errors=True)
+        raise
+    with mcp:
         # Build the tool list: filtered MCP tools + synthetic signal_done.
         tools = [
             t for t in mcp.tools
@@ -268,6 +276,14 @@ def run_mcp_agent(
                         "tool_call_id": tc.id,
                         "content": result_text,
                     })
+                    tool_records.append(McpToolCall(
+                        tool_name=tool_name,
+                        arguments=args,
+                        result_text=result_text,
+                        had_image=had_image,
+                        duration_s=duration_s,
+                    ))
+                    break  # don't dispatch any further tools in this batch
                 else:
                     t_call = time.monotonic()
                     print(f"  {tag} → {tool_name}(…)", end="", flush=True)
@@ -384,9 +400,9 @@ def _append_seed_render(
                 "execute",
                 {"code": (
                     f"from build123d import import_step\n"
-                    f"_seed = import_step('{step_path.name}')\n"
+                    f"_seed = import_step(r'{step_path}')\n"
                     f"show(_seed, 'input')\n"
-                    f"print('Loaded input STEP:', '{step_path.name}')"
+                    f"print('Loaded input STEP:', r'{step_path}')"
                 )},
             )
             render_text, render_png = mcp.call_tool(

--- a/src/cadgenbench/mcp_agent/agent.py
+++ b/src/cadgenbench/mcp_agent/agent.py
@@ -1,0 +1,415 @@
+# Copyright 2026 Hugging Face
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MCP-agent loop: task description → LLM tool calls → build123d-mcp → STEP.
+
+The agent uses native LLM tool-calling (via LiteLLM) instead of the
+baseline's code-block extraction pattern. The build123d-mcp server handles
+execution, rendering, and measurement; a synthetic ``signal_done`` tool is
+the completion signal.
+
+Stopping conditions (agent is unaware of the budget/iteration limits):
+  - Model calls ``signal_done`` and ``output.step`` exists
+  - Token budget exhausted (``max_total_tokens``)
+  - Iteration cap (``max_iterations``)
+  - Wall-clock timeout (``max_duration_s``)
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import shutil
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from cadgenbench.baseline.llm import LLMClient
+from cadgenbench.mcp_agent.mcp_client import McpSession
+from cadgenbench.mcp_agent.prompt import SIGNAL_DONE_TOOL, assemble_messages
+from cadgenbench.mcp_agent.types import (
+    McpAgentConfig,
+    McpAgentResult,
+    McpToolCall,
+    McpTurnRecord,
+    save_mcp_conversation,
+)
+
+logger = logging.getLogger(__name__)
+
+# Name of the output artifact the evaluator requires.
+ARTIFACT_FILENAME = "output.step"
+
+# Only expose a focused subset of MCP tools to the LLM by default.
+# This keeps the tool list short, which helps model attention and reduces
+# token cost. Advanced tools (clearance, cross_sections, etc.) can be added
+# by extending this set.
+_ALLOWED_MCP_TOOLS = {
+    "execute",
+    "render_view",
+    "measure",
+    "export",
+    "import_step",
+}
+
+
+def run_mcp_agent(
+    task_description: str,
+    config: McpAgentConfig = McpAgentConfig(),
+    input_files: list[Path] | None = None,
+    work_dir: Path | None = None,
+    output_dir: Path | None = None,
+) -> McpAgentResult:
+    """Run the MCP-agent CAD generation loop.
+
+    Args:
+        task_description: What the user wants built.
+        config: All tuneable parameters.
+        input_files: Optional image/STEP files for the initial prompt.
+            STEP files are copied into work_dir so the MCP server can
+            access them via import_step().
+        work_dir: Directory where output.step will land. Created as a
+            temp dir if not provided.
+        output_dir: If provided, saves results incrementally each turn.
+
+    Returns:
+        McpAgentResult with per-turn records, totals, and stopping reason.
+    """
+    if work_dir is None:
+        work_dir = Path(tempfile.mkdtemp(prefix="cadgenbench_mcp_"))
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    # Copy STEP inputs into work_dir so import_step() can find them.
+    if input_files:
+        for src in input_files:
+            if src.suffix.lower() in {".step", ".stp"}:
+                dest = work_dir / src.name
+                if dest.resolve() != src.resolve():
+                    shutil.copy2(src, dest)
+
+    # The model is told to export to this exact path.  work_dir is under
+    # tempfile.gettempdir(), so build123d-mcp's safe_output_path() allows it.
+    output_step = work_dir / ARTIFACT_FILENAME
+
+    # LLMClient with streaming disabled — tool-call reassembly via streaming
+    # adds complexity; direct non-streaming calls are simpler and reliable
+    # for Anthropic/OpenAI targets.
+    client = LLMClient(model=config.model, timeout=config.llm_timeout, stream=False)
+
+    turns: list[McpTurnRecord] = []
+    total_tokens = 0
+    stopped_reason = "max_iterations"
+    t0 = time.monotonic()
+
+    def _build_result(step: Path | None = None) -> McpAgentResult:
+        return McpAgentResult(
+            task_description=task_description,
+            config=config,
+            turns=turns,
+            total_tokens=total_tokens,
+            total_duration_s=time.monotonic() - t0,
+            completed=stopped_reason == "done",
+            stopped_reason=stopped_reason,
+            work_dir=work_dir,
+            candidate_step=step,
+        )
+
+    def _save(step: Path | None = None) -> None:
+        if output_dir is None:
+            return
+        try:
+            _build_result(step).save(output_dir)
+            save_mcp_conversation(turns, output_dir)
+        except Exception:
+            logger.warning("Incremental save failed", exc_info=True)
+
+    with McpSession(config.mcp_server_command, config.mcp_server_args) as mcp:
+        # Build the tool list: filtered MCP tools + synthetic signal_done.
+        tools = [
+            t for t in mcp.tools
+            if t["function"]["name"] in _ALLOWED_MCP_TOOLS
+        ] + [SIGNAL_DONE_TOOL]
+
+        messages = assemble_messages(
+            task_description,
+            output_step_path=str(output_step),
+            input_files=input_files,
+        )
+
+        # Inject initial render of any seeded STEP so the model sees the
+        # starting geometry without having to render it itself.
+        step_inputs = [
+            f for f in (input_files or []) if f.suffix.lower() in {".step", ".stp"}
+        ]
+        if step_inputs:
+            _append_seed_render(messages, step_inputs, mcp)
+
+        for turn_idx in range(config.max_iterations):
+            elapsed = time.monotonic() - t0
+            if elapsed >= config.max_duration_s:
+                stopped_reason = "timeout"
+                print(
+                    f"  [turn {turn_idx}] Timeout ({elapsed:.0f}s >= "
+                    f"{config.max_duration_s:.0f}s)",
+                    flush=True,
+                )
+                break
+
+            if total_tokens >= config.max_total_tokens:
+                stopped_reason = "max_tokens"
+                print(
+                    f"  [turn {turn_idx}] Token budget exhausted "
+                    f"({total_tokens} >= {config.max_total_tokens})",
+                    flush=True,
+                )
+                break
+
+            tag = f"[turn {turn_idx}]"
+            turn_t0 = time.monotonic()
+
+            print(f"  {tag} Calling LLM…", end="", flush=True)
+            remaining_s = max(0.0, config.max_duration_s - (time.monotonic() - t0))
+            if remaining_s < 1.0:
+                stopped_reason = "timeout"
+                break
+
+            completion = client.complete(
+                messages,
+                max_tokens=config.max_tokens,
+                temperature=config.temperature,
+                tools=tools,
+                tool_choice="auto",
+            )
+            total_tokens += completion.total_tokens
+            print(
+                f" {completion.total_tokens} tok "
+                f"({completion.prompt_tokens}+{completion.completion_tokens})",
+                flush=True,
+            )
+
+            assistant_text = completion.content or ""
+            raw_tool_calls = completion.tool_calls or []
+
+            # --- Dispatch tool calls -----------------------------------------
+
+            tool_records: list[McpToolCall] = []
+            done_signaled = False
+
+            # Build the assistant message including any tool_call metadata so
+            # the conversation is valid for the next round.
+            assistant_msg: dict[str, Any] = {
+                "role": "assistant",
+                "content": assistant_text or None,
+            }
+            if raw_tool_calls:
+                assistant_msg["tool_calls"] = [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        },
+                    }
+                    for tc in raw_tool_calls
+                ]
+            messages.append(assistant_msg)
+
+            if not raw_tool_calls:
+                # No tool calls — remind the model to use tools.
+                print(f"  {tag} No tool calls in response", flush=True)
+                messages.append({
+                    "role": "user",
+                    "content": (
+                        "Please use the available tools to make progress on the task. "
+                        "Call execute() with build123d code, then verify with measure() "
+                        "and render_view(), then export() when done."
+                    ),
+                })
+                turns.append(McpTurnRecord(
+                    turn=turn_idx,
+                    assistant_text=assistant_text,
+                    tool_calls=[],
+                    prompt_tokens=completion.prompt_tokens,
+                    completion_tokens=completion.completion_tokens,
+                    duration_s=time.monotonic() - turn_t0,
+                    reasoning_tokens=completion.reasoning_tokens,
+                ))
+                _save()
+                continue
+
+            # Process each tool call and append tool result messages.
+            for tc in raw_tool_calls:
+                tool_name = tc.function.name
+                try:
+                    args = json.loads(tc.function.arguments or "{}")
+                except json.JSONDecodeError:
+                    args = {}
+
+                if tool_name == "signal_done":
+                    done_signaled = True
+                    result_text = "Completion signal received."
+                    had_image = False
+                    duration_s = 0.0
+                    messages.append({
+                        "role": "tool",
+                        "tool_call_id": tc.id,
+                        "content": result_text,
+                    })
+                else:
+                    t_call = time.monotonic()
+                    print(f"  {tag} → {tool_name}(…)", end="", flush=True)
+                    try:
+                        result_text, png_bytes = mcp.call_tool(tool_name, args)
+                    except Exception as exc:
+                        result_text = f"Tool error: {exc}"
+                        png_bytes = None
+                    duration_s = time.monotonic() - t_call
+                    had_image = png_bytes is not None
+                    status = " [+img]" if had_image else ""
+                    print(f" {duration_s:.1f}s{status}", flush=True)
+
+                    # Build tool result content.  For Anthropic models,
+                    # include the image inline; for others use text only.
+                    tool_content: Any
+                    if had_image and _supports_image_tool_results(config.model):
+                        b64 = base64.b64encode(png_bytes).decode()  # type: ignore[arg-type]
+                        tool_content = [
+                            {"type": "text", "text": result_text},
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": f"data:image/png;base64,{b64}"},
+                            },
+                        ]
+                    else:
+                        tool_content = result_text
+                        if had_image:
+                            tool_content += "\n(image rendered but not shown for this provider)"
+
+                    messages.append({
+                        "role": "tool",
+                        "tool_call_id": tc.id,
+                        "content": tool_content,
+                    })
+
+                tool_records.append(McpToolCall(
+                    tool_name=tool_name,
+                    arguments=args,
+                    result_text=result_text,
+                    had_image=had_image,
+                    duration_s=duration_s,
+                ))
+
+            turns.append(McpTurnRecord(
+                turn=turn_idx,
+                assistant_text=assistant_text,
+                tool_calls=tool_records,
+                prompt_tokens=completion.prompt_tokens,
+                completion_tokens=completion.completion_tokens,
+                duration_s=time.monotonic() - turn_t0,
+                reasoning_tokens=completion.reasoning_tokens,
+            ))
+
+            # --- Check done signal -------------------------------------------
+
+            if done_signaled:
+                if not output_step.exists():
+                    # Reject done: no artifact yet. Tell model to export first.
+                    print(f"  {tag} signal_done rejected — no {ARTIFACT_FILENAME}", flush=True)
+                    messages.append({
+                        "role": "user",
+                        "content": (
+                            f"signal_done rejected: `{output_step}` does not exist. "
+                            f"Call `export(\"{output_step}\", format=\"step\")` first, "
+                            "then call signal_done()."
+                        ),
+                    })
+                    _save()
+                    continue
+
+                stopped_reason = "done"
+                print(f"  {tag} Done — {ARTIFACT_FILENAME} found", flush=True)
+                _save(output_step)
+                break
+
+            if total_tokens >= config.max_total_tokens:
+                stopped_reason = "max_tokens"
+                _save(output_step if output_step.exists() else None)
+                break
+
+            _save(output_step if output_step.exists() else None)
+
+    result = _build_result(output_step if output_step.exists() else None)
+
+    if output_dir is not None:
+        result.save(output_dir)
+        save_mcp_conversation(turns, output_dir)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _supports_image_tool_results(model: str) -> bool:
+    """True for providers known to accept image content in tool results."""
+    return "anthropic" in model or "claude" in model
+
+
+def _append_seed_render(
+    messages: list[dict[str, Any]],
+    step_paths: list[Path],
+    mcp: McpSession,
+) -> None:
+    """For editing tasks: render the input STEP(s) and append to the first
+    user message so the model sees the starting geometry immediately."""
+    blocks: list[dict[str, Any]] = []
+    for step_path in step_paths:
+        # Ask the MCP server to render the seeded file.
+        try:
+            text, png = mcp.call_tool(
+                "execute",
+                {"code": (
+                    f"from build123d import import_step\n"
+                    f"_seed = import_step('{step_path.name}')\n"
+                    f"show(_seed, 'input')\n"
+                    f"print('Loaded input STEP:', '{step_path.name}')"
+                )},
+            )
+            render_text, render_png = mcp.call_tool(
+                "render_view",
+                {"direction": "iso", "objects": "input"},
+            )
+        except Exception as exc:
+            blocks.append({"type": "text", "text": f"Could not pre-render {step_path.name}: {exc}"})
+            continue
+
+        blocks.append({"type": "text", "text": f"### Starting geometry: {step_path.name}\n{render_text}"})
+        if render_png is not None:
+            b64 = base64.b64encode(render_png).decode()
+            blocks.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{b64}"},
+            })
+
+    if not blocks:
+        return
+
+    user_msg = messages[-1]
+    content = user_msg["content"]
+    if isinstance(content, str):
+        content = [{"type": "text", "text": content}]
+    user_msg["content"] = content + blocks

--- a/src/cadgenbench/mcp_agent/mcp_client.py
+++ b/src/cadgenbench/mcp_agent/mcp_client.py
@@ -1,0 +1,185 @@
+# Copyright 2026 Hugging Face
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Synchronous wrapper around a build123d-mcp stdio server.
+
+Architecture:
+  McpSession (main thread)
+    └── background daemon thread running an asyncio event loop
+         └── mcp.ClientSession ←─── stdio ───→ build123d-mcp subprocess
+
+The MCP session (and its subprocess) stays alive for the full agent run.
+Tool calls are dispatched via asyncio.run_coroutine_threadsafe() so the
+main thread stays blocking-sync while the async MCP protocol runs in the
+background loop.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import threading
+from typing import Any
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+class McpSession:
+    """Long-lived synchronous proxy for a build123d-mcp MCP server.
+
+    Usage::
+
+        with McpSession("build123d-mcp") as session:
+            text, png = session.call_tool("execute", {"code": "..."})
+            tools = session.tools  # LiteLLM-format tool defs
+    """
+
+    def __init__(self, command: str, args: list[str] | None = None) -> None:
+        self._params = StdioServerParameters(command=command, args=args or [])
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._session: ClientSession | None = None
+        self._shutdown: asyncio.Event | None = None
+        self._ready = threading.Event()
+        self._init_error: Exception | None = None
+        self._tools: list[dict[str, Any]] = []
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the background event loop and connect to the MCP server."""
+        self._thread = threading.Thread(
+            target=self._run_loop, daemon=True, name="mcp-event-loop"
+        )
+        self._thread.start()
+        if not self._ready.wait(timeout=90):
+            raise TimeoutError("MCP server did not become ready within 90 s")
+        if self._init_error is not None:
+            raise self._init_error
+
+    def close(self) -> None:
+        """Signal shutdown and wait for the background thread to exit."""
+        if self._loop is not None and self._shutdown is not None:
+            self._loop.call_soon_threadsafe(self._shutdown.set)
+        if self._thread is not None:
+            self._thread.join(timeout=15)
+
+    def __enter__(self) -> "McpSession":
+        self.start()
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Tool introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def tools(self) -> list[dict[str, Any]]:
+        """LiteLLM (OpenAI-format) tool definitions from the MCP server."""
+        return self._tools
+
+    # ------------------------------------------------------------------
+    # Tool dispatch
+    # ------------------------------------------------------------------
+
+    def call_tool(
+        self, name: str, arguments: dict[str, Any]
+    ) -> tuple[str, bytes | None]:
+        """Call an MCP tool synchronously.
+
+        Returns ``(text_result, png_bytes)`` where ``png_bytes`` is the
+        first PNG image in the tool result, or ``None`` if no image was
+        returned.
+        """
+        if self._loop is None or self._session is None:
+            raise RuntimeError("McpSession has not been started")
+        future = asyncio.run_coroutine_threadsafe(
+            self._call_async(name, arguments), self._loop
+        )
+        return future.result(timeout=300)
+
+    # ------------------------------------------------------------------
+    # Private async helpers (run in background loop)
+    # ------------------------------------------------------------------
+
+    def _run_loop(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        try:
+            self._loop.run_until_complete(self._run_session())
+        finally:
+            self._loop.close()
+
+    async def _run_session(self) -> None:
+        self._shutdown = asyncio.Event()
+        try:
+            async with stdio_client(self._params) as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    resp = await session.list_tools()
+                    self._tools = _convert_tools(resp.tools)
+                    self._session = session
+                    self._ready.set()
+                    await self._shutdown.wait()
+        except Exception as exc:  # noqa: BLE001
+            self._init_error = exc
+            self._ready.set()
+
+    async def _call_async(
+        self, name: str, arguments: dict[str, Any]
+    ) -> tuple[str, bytes | None]:
+        result = await self._session.call_tool(name, arguments)  # type: ignore[union-attr]
+        texts: list[str] = []
+        png: bytes | None = None
+        for block in result.content:
+            if block.type == "text":
+                texts.append(block.text)
+            elif (
+                block.type == "image"
+                and getattr(block, "mimeType", "") == "image/png"
+                and png is None
+            ):
+                png = base64.b64decode(block.data)
+        return "\n".join(texts), png
+
+
+# ---------------------------------------------------------------------------
+# Schema conversion
+# ---------------------------------------------------------------------------
+
+def _convert_tools(mcp_tools: list[Any]) -> list[dict[str, Any]]:
+    """Convert MCP tool objects to LiteLLM (OpenAI-format) tool defs.
+
+    The first sentence of the description is kept to stay within provider
+    token limits for tool definitions. ``$schema`` is stripped because some
+    providers reject it as an unrecognised keyword.
+    """
+    result = []
+    for t in mcp_tools:
+        schema = dict(t.inputSchema or {"type": "object", "properties": {}})
+        schema.pop("$schema", None)
+        desc = (t.description or "").split("\n")[0][:512]
+        result.append({
+            "type": "function",
+            "function": {
+                "name": t.name,
+                "description": desc,
+                "parameters": schema,
+            },
+        })
+    return result

--- a/src/cadgenbench/mcp_agent/mcp_client.py
+++ b/src/cadgenbench/mcp_agent/mcp_client.py
@@ -61,6 +61,8 @@ class McpSession:
 
     def start(self) -> None:
         """Start the background event loop and connect to the MCP server."""
+        if self._thread is not None:
+            return  # already started; idempotent
         self._thread = threading.Thread(
             target=self._run_loop, daemon=True, name="mcp-event-loop"
         )
@@ -139,6 +141,8 @@ class McpSession:
         except Exception as exc:  # noqa: BLE001
             self._init_error = exc
             self._ready.set()
+        finally:
+            self._session = None  # guard: call_tool() raises RuntimeError if session dies
 
     async def _call_async(
         self, name: str, arguments: dict[str, Any]

--- a/src/cadgenbench/mcp_agent/prompt.py
+++ b/src/cadgenbench/mcp_agent/prompt.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Hugging Face
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""System prompt assembly for the MCP-agent strategy.
+
+Unlike the baseline (which teaches code-block extraction), this prompt is
+oriented around tool-calling: execute(), measure(), render_view(), export(),
+signal_done(). The build123d cheat sheet is shared from the baseline package.
+"""
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Any
+
+_CHEAT_SHEET = (
+    (Path(__file__).parent.parent / "baseline" / "build123d_cheat_sheet.md")
+    .read_text()
+    .strip()
+)
+
+_IMAGE_MIME_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
+_STEP_SUFFIXES = {".step", ".stp"}
+
+
+def build_system_prompt(output_step_path: str) -> str:
+    """Return the full system prompt, embedding the target export path."""
+    return f"""\
+You are an expert CAD engineer. You build precise 3D models using build123d, \
+a Python CAD framework built on OpenCascade.
+
+You work through a set of tools that connect to a persistent build123d session. \
+All named objects created with show() survive across tool calls — you never need \
+to rebuild geometry from scratch within a run.
+
+## Workflow
+
+1. **Build geometry** — call `execute(code)` with build123d Python code.
+   Use `show(shape, "name")` to register named shapes.
+2. **Verify topology** — call `measure()` after every boolean operation (cut, \
+fuse, intersect). Confirm face count changed as expected; a stale count means \
+the operation silently failed.
+3. **Render** — call `render_view(direction="iso")` to visually inspect. Use \
+`measure()` first — it is faster and unambiguous.
+4. **Export** — when satisfied, call:
+   `export("{output_step_path}", format="step")`
+   This exact path is required; the evaluator reads it from there.
+5. **Signal done** — call `signal_done()`. Only after a successful export.
+
+## Code in execute()
+
+- Each execute() call shares the same persistent session. Variables and imports \
+persist across calls.
+- Always `show(shape, "name")` after creating geometry so render_view and \
+measure can reference it.
+- After boolean operations call measure() before rendering — rendering confirms \
+appearance, measure() confirms geometry.
+- Use named dimension variables (`wall_t = 3`) rather than magic numbers.
+- No stubs, no pass, no TODOs — write complete working code.
+
+## Editing tasks
+
+If a starting STEP is provided: call `import_step("input.step")` in your first \
+execute() call to load it into the session. Apply the requested changes, then \
+export as above.
+
+## build123d reference
+
+{_CHEAT_SHEET}
+"""
+
+
+# Synthetic tool definition added to the MCP tool list on the client side.
+# The model calls this to signal it is done; it is never forwarded to the
+# MCP server.
+SIGNAL_DONE_TOOL: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "signal_done",
+        "description": (
+            "Signal that the CAD model is complete. Call ONLY after you have "
+            "successfully exported output.step via the export() tool and verified "
+            "the geometry with measure(). The run ends when this is called."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "notes": {
+                    "type": "string",
+                    "description": "Optional brief summary of the completed model.",
+                }
+            },
+            "required": [],
+        },
+    },
+}
+
+
+def assemble_messages(
+    task_description: str,
+    output_step_path: str,
+    input_files: list[Path] | None = None,
+) -> list[dict[str, Any]]:
+    """Build the initial messages list for the MCP agent.
+
+    STEP input files are not inlined (too large); the prompt tells the model
+    they are available in the MCP server's session. Images are inlined as
+    base64 content blocks.
+    """
+    system_prompt = build_system_prompt(output_step_path)
+
+    step_files = [f for f in (input_files or []) if f.suffix.lower() in _STEP_SUFFIXES]
+    image_files = [
+        f for f in (input_files or []) if f.suffix.lower() in _IMAGE_MIME_TYPES
+    ]
+
+    user_text = task_description
+    if step_files:
+        names = ", ".join(f"`{p.name}`" for p in step_files)
+        user_text = (
+            f"{task_description}\n\n"
+            f"Starting STEP file(s) {names} have been placed in the MCP server "
+            f"working directory. Load with `import_step(\"<filename>\")` inside "
+            f"an `execute()` call."
+        )
+
+    if not image_files:
+        return [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_text},
+        ]
+
+    content: list[dict[str, Any]] = [{"type": "text", "text": user_text}]
+    for img in image_files:
+        content.append(_image_block(img))
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": content},
+    ]
+
+
+def _image_block(path: Path) -> dict[str, Any]:
+    mime = _IMAGE_MIME_TYPES[path.suffix.lower()]
+    data = base64.b64encode(path.read_bytes()).decode()
+    return {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{data}"}}

--- a/src/cadgenbench/mcp_agent/types.py
+++ b/src/cadgenbench/mcp_agent/types.py
@@ -1,0 +1,161 @@
+# Copyright 2026 Hugging Face
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data types for the MCP-agent strategy."""
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Per-tool-call record
+# ---------------------------------------------------------------------------
+
+@dataclass
+class McpToolCall:
+    """Record of one LLM-initiated tool call."""
+
+    tool_name: str
+    arguments: dict[str, Any]
+    result_text: str
+    had_image: bool
+    duration_s: float
+
+
+# ---------------------------------------------------------------------------
+# Per-turn record
+# ---------------------------------------------------------------------------
+
+@dataclass
+class McpTurnRecord:
+    """Everything that happened in one agent turn (one LLM completion)."""
+
+    turn: int
+    assistant_text: str        # text portion of the assistant message
+    tool_calls: list[McpToolCall]
+    prompt_tokens: int
+    completion_tokens: int
+    duration_s: float
+    reasoning_tokens: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class McpAgentConfig:
+    """Tuneable parameters for the MCP-agent run."""
+
+    model: str = "anthropic/claude-sonnet-4-6"
+    temperature: float = 1.0
+    max_tokens: int = 16384           # per-LLM-call completion budget
+    max_total_tokens: int = 500_000   # global token budget
+    max_iterations: int = 60          # agent turn cap
+    max_duration_s: float = 1800.0    # wall-clock timeout (seconds)
+    llm_timeout: float = 300.0        # per-LLM-call timeout (seconds)
+    # Command + args to launch the build123d-mcp server over stdio.
+    # Defaults assume `build123d-mcp` is on PATH (pip-installed).
+    # Alternative: mcp_server_command="uvx", mcp_server_args=["build123d-mcp"]
+    mcp_server_command: str = "build123d-mcp"
+    mcp_server_args: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Agent result
+# ---------------------------------------------------------------------------
+
+@dataclass
+class McpAgentResult:
+    """Full output of an MCP-agent run."""
+
+    task_description: str
+    config: McpAgentConfig
+    turns: list[McpTurnRecord]
+    total_tokens: int
+    total_duration_s: float
+    completed: bool
+    stopped_reason: str   # "done" | "max_tokens" | "max_iterations" | "timeout"
+    work_dir: Path | None = None
+    candidate_step: Path | None = None
+
+    def save(self, output_dir: str | Path) -> Path:
+        """Persist artefacts to disk in the same layout as the baseline.
+
+        The canonical ``output.step`` at the fixture root is required by
+        the evaluator. Per-turn tool call logs land in ``turn_<N>/``.
+        """
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+
+        for rec in self.turns:
+            turn_dir = out / f"turn_{rec.turn}"
+            turn_dir.mkdir(exist_ok=True)
+            for i, tc in enumerate(rec.tool_calls):
+                (turn_dir / f"tool_{i:02d}_{tc.tool_name}.txt").write_text(
+                    f"tool: {tc.tool_name}\n"
+                    f"args: {json.dumps(tc.arguments, indent=2)}\n\n"
+                    f"result ({tc.duration_s:.1f}s, image={tc.had_image}):\n"
+                    f"{tc.result_text}"
+                )
+
+        # Materialise canonical candidate STEP at the fixture root.
+        if self.candidate_step and self.candidate_step.exists():
+            dest = out / "output.step"
+            if dest.resolve() != self.candidate_step.resolve():
+                shutil.copy2(self.candidate_step, dest)
+
+        debug: dict[str, Any] = {
+            "stopped_reason": self.stopped_reason,
+            "total_duration_s": round(self.total_duration_s, 2),
+            "total_tokens": self.total_tokens,
+            "turns": len(self.turns),
+        }
+        (out / "mcp_agent_debug.json").write_text(json.dumps(debug, indent=2))
+        return out
+
+
+def save_mcp_conversation(turns: list[McpTurnRecord], output_dir: Path) -> None:
+    """Write a JSON log of the full conversation for debugging."""
+    log = []
+    for rec in turns:
+        log.append({
+            "turn": rec.turn,
+            "assistant_text": rec.assistant_text,
+            "tool_calls": [
+                {
+                    "tool": tc.tool_name,
+                    "arguments": tc.arguments,
+                    "result_preview": (
+                        tc.result_text[:400] + "…"
+                        if len(tc.result_text) > 400 else tc.result_text
+                    ),
+                    "had_image": tc.had_image,
+                    "duration_s": round(tc.duration_s, 2),
+                }
+                for tc in rec.tool_calls
+            ],
+            "tokens": {
+                "prompt": rec.prompt_tokens,
+                "completion": rec.completion_tokens,
+            },
+        })
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "conversation.json").write_text(
+        json.dumps(log, indent=2, default=str)
+    )


### PR DESCRIPTION
## Summary

Adds a new `mcp-agent` strategy for CADGenBench that uses the [build123d-mcp](https://github.com/pzfreo/build123d-mcp) server's native tool-calling interface instead of code-block extraction. The LLM uses `execute`, `render_view`, `measure`, `export`, and a synthetic `signal_done` tool directly via the MCP protocol.

Key design decisions:
- **Provider-agnostic**: uses LiteLLM (already a baseline dependency), not Anthropic SDK directly
- **Async-to-sync bridge**: background daemon thread runs the MCP asyncio event loop; main agent loop stays synchronous
- **Image tool results**: inlined as `image_url` blocks for Anthropic/Claude models; text-only note for others

### Code review fixes (7 issues, critical → medium)

| Severity | File | Fix |
|----------|------|-----|
| Critical | `baseline/llm.py` | `getattr` for `finish_reason` — direct access broke all 42 `test_llm.py` tests |
| Critical | `mcp_agent/agent.py` | `import_step` now uses absolute path; bare filename fails because MCP server cwd ≠ work_dir |
| High | `mcp_agent/agent.py` | Break tool-call loop on `signal_done` — subsequent batch tools no longer dispatch to MCP |
| High | `mcp_agent/agent.py` + `mcp_client.py` | Clean up tmpdir on `McpSession.start()` failure; `start()` made idempotent |
| Medium | `mcp_agent/mcp_client.py` | Clear `self._session = None` in finally so mid-run server crash gives clean `RuntimeError` via None-guard |
| Medium | `mcp_agent/_cli.py` | Remove dead `DISPLAYED_METRICS` constant (closure captures `baseline._cli`'s copy) and unused `import yaml` |
| Medium | `baseline/_cli.py` | Move heavy imports inside functions so `_discover_fixtures` no longer drags litellm at import time |

## Test plan

- [x] `uv run --extra baseline python -m pytest tests/baseline/` — 97 passed
- [x] `uv run --extra baseline python -m pytest tests/baseline/test_llm.py` — 42 passed (was broken by `finish_reason` bug)
- [x] All modified files pass `ast.parse` (syntax check)
- [x] `from cadgenbench.baseline._cli import _discover_fixtures` importable without litellm installed
- [ ] End-to-end: `cadgenbench mcp-agent run <fixture>` with a running build123d-mcp server

🤖 Generated with [Claude Code](https://claude.com/claude-code)